### PR TITLE
Improve printing %c as bytes

### DIFF
--- a/src/main/java/EOorg/EOeolang/EOtxt/EOsprintf.java
+++ b/src/main/java/EOorg/EOeolang/EOtxt/EOsprintf.java
@@ -104,7 +104,8 @@ public class EOsprintf extends PhDefault {
         if (occurrence != -1) {
             final String flag = format.substring(occurrence, occurrence + 2);
             if (CHAR_FLAG.equalsIgnoreCase(flag)) {
-                result = (char) ((byte[]) arg)[0];
+                final byte[] arr = (byte[]) arg;
+                result = (char) arr[arr.length - 1];
             }
         }
         return result;

--- a/src/test/eo/org/eolang/txt/sprintf-tests.eo
+++ b/src/test/eo/org/eolang/txt/sprintf-tests.eo
@@ -46,5 +46,13 @@
 
 [] > prints-bytes-string
   assert-that > @
-    sprintf "%c" (56.as-bytes.slice 7 1)
-    $.equal-to "8"
+    sprintf "%c" (100.as-bytes)
+    $.equal-to "d"
+
+[] > prints-bytes-and-complex-string
+  assert-that > @
+    sprintf "%c %s %c abc"
+      (100.as-bytes)
+      "e f"
+      (56.as-bytes)
+    $.equal-to "d e f 8 abc"


### PR DESCRIPTION
@Graur @EugeneDar This is fix of objectionary/eo-strings#40
I changed implementation of printing `%c` and added test. Please comment