### PR TITLE
Add `text.is-ascii`

### DIFF
--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -395,7 +395,35 @@
         00-00-00-00-00-00-00
         b
 
-  # Returns concatenaion of all strings
+  # Check that all signs in string are ASCII characters.
+  [] > is-ascii
+    reduced. > @
+      list
+        bytes-as-array
+          as-bytes.
+            text
+              s
+      TRUE
+      [a x]
+        as-int. > value!
+          is-alphabetic.bytes-1-to-8
+            as-bytes.
+              x
+        and. > @
+          a
+          int-is-ascii
+            value
+
+    [b] > int-is-ascii
+      and. > @
+        gte.
+          b
+          0
+        lte.
+          b
+          127
+
+  # Returns concatenation of all strings
   [others...] > chained
     text > @
       as-string.

--- a/src/test/eo/org/eolang/txt/text-tests.eo
+++ b/src/test/eo/org/eolang/txt/text-tests.eo
@@ -510,6 +510,27 @@
         "123"
     $.equal-to FALSE
 
+[] > check-is-ascii
+  assert-that > @
+    is-ascii.
+      text
+        "H311oW"
+    $.equal-to TRUE
+
+[] > check-is-ascii2
+  assert-that > @
+    is-ascii.
+      text
+        "🌵"
+    $.equal-to FALSE
+
+[] > check-is-ascii3
+  assert-that > @
+    is-alphabetic.
+      text
+        "ascИ"
+    $.equal-to FALSE
+
 [] > split-text
   assert-that > @
     split.

--- a/src/test/eo/org/eolang/txt/text-tests.eo
+++ b/src/test/eo/org/eolang/txt/text-tests.eo
@@ -526,10 +526,10 @@
 
 [] > check-is-ascii3
   assert-that > @
-    is-alphabetic.
+    is-ascii.
       text
-        "ascИ"
-    $.equal-to FALSE
+        "123"
+    $.equal-to TRUE
 
 [] > split-text
   assert-that > @


### PR DESCRIPTION
closes #127 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to the `text` module in the form of three new tests and two new methods, `is-ascii` and `bytes-1-to-8`. The `is-ascii` method checks if all characters in a string are ASCII characters, while `bytes-1-to-8` returns a concatenation of all strings. 

### Detailed summary
- Added three new tests to `text-tests.eo`
    - `check-is-ascii`
    - `check-is-ascii2`
    - `check-is-ascii3`
- Added two new methods to `text.eo`
    - `is-ascii`
    - `bytes-1-to-8`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->