### PR TITLE
text.left-trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,3 @@ $ mvn clean install -Pqulice
 ```
 
 You will need Maven 3.3+ and Java 8+.
-
-

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ This is how it works:
 ### Text
 The object `QQ.txt.text` is a decorator of `QQ.string`.
 
-The attribute `is-empty` is TRUE if the length of the
-tuple is zero.
+The attribute `is-empty` is TRUE if the length of the tuple is zero.
 
 The attribute `trim` is a new string trimmed from both sides.
 

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -36,7 +36,7 @@
     text > @
       ^.s.slice start len
 
-  # Trim it from left side
+  # Returns string trimmed from left side
   [] > left-trim
     as-string. > @
       reduced.

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -38,10 +38,10 @@
 
   # Returns string trimmed from left side
   [] > left-trim
-    rec-trim > @
+    left-rec-trim > @
       s
 
-    [str] > rec-trim
+    [str] > left-rec-trim
       if. > @
         eq.
           length.
@@ -55,7 +55,7 @@
               0
               1
             " "
-          rec-trim
+          left-rec-trim
             slice.
               str
               1

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -36,6 +36,36 @@
     text > @
       ^.s.slice start len
 
+  # Trim it from left side
+  [] > left-trim
+    rec-trim > @
+      s
+
+    [str] > rec-trim
+      eq. > empty!
+        length.
+          str
+        0
+      eq. > starts-with-space!
+        slice.
+          const-str
+          0
+          1
+        " "
+      if. > @
+        empty
+        ""
+        if.
+          starts-with-space
+          rec-trim
+            slice
+              1
+              plus.
+                length.
+                  const-str
+                -1
+          str
+
   # Trim it from both sides
   # @todo #107:30min Current implementation of trimmed method catches stackoverflow
   #  for tests where both sides of strings are changing or just more than one space

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -48,7 +48,7 @@
         0
       eq. > starts-with-space!
         slice.
-          const-str
+          str
           0
           1
         " "
@@ -62,7 +62,7 @@
               1
               plus.
                 length.
-                  const-str
+                  str
                 -1
           str
 

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -51,10 +51,10 @@
         if.
           eq.
             slice.
-                str
-                0
-                1
-              " "
+              str
+              0
+              1
+            " "
           rec-trim
             slice.
               str

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -38,10 +38,10 @@
 
   # Trim it from left side
   [] > left-trim
-    rec-trim > @
+    rec-left-trim > @
       s
 
-    [str] > rec-trim
+    [str] > rec-left-trim
       eq. > empty!
         length.
           str
@@ -57,7 +57,7 @@
         ""
         if.
           starts-with-space
-          rec-trim
+          rec-left-trim
             slice
               1
               plus.

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -38,32 +38,23 @@
 
   # Returns string trimmed from left side
   [] > left-trim
-    left-rec-trim > @
-      s
+    if. > @
+      eq.
+        length.
+          s
+        0
+      ""
+      left-trim-rec.
+        s
 
     [str] > left-rec-trim
       if. > @
         eq.
-          length.
-            str
-          0
-        ""
-        if.
-          eq.
-            slice.
-              str
-              0
-              1
-            " "
-          left-rec-trim
-            slice.
-              str
-              1
-              plus.
-                length.
-                  str
-                -1
-          str
+          str.slice 0 1
+          " "
+        left-rec-trim.
+          str.slice 1 (str.length)
+      str
 
   # Trim it from both sides
   # @todo #107:30min Current implementation of trimmed method catches stackoverflow

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -38,33 +38,25 @@
 
   # Trim it from left side
   [] > left-trim
-    rec-left-trim > @
-      s
-
-    [str] > rec-left-trim
-      eq. > empty!
-        length.
-          str
-        0
-      eq. > starts-with-space!
-        slice.
-          str
-          0
-          1
-        " "
-      if. > @
-        empty
-        ""
-        if.
-          starts-with-space
-          rec-left-trim
-            slice
-              1
-              plus.
-                length.
-                  str
-                -1
-          str
+    as-string. > @
+      reduced.
+        list
+          bytes-as-array
+            s.as-bytes
+        --
+        [a x]
+          if. > @
+            and.
+              eq.
+                a.as-string
+                ""
+              eq.
+                x.as-string
+                " "
+            ""
+            concat.
+              a
+              x
 
   # Trim it from both sides
   # @todo #107:30min Current implementation of trimmed method catches stackoverflow

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -38,25 +38,32 @@
 
   # Returns string trimmed from left side
   [] > left-trim
-    as-string. > @
-      reduced.
-        list
-          bytes-as-array
-            s.as-bytes
-        --
-        [a x]
-          if. > @
-            and.
-              eq.
-                a.as-string
-                ""
-              eq.
-                x.as-string
-                " "
-            ""
-            concat.
-              a
-              x
+    rec-trim > @
+      s
+
+    [str] > rec-trim
+      if. > @
+        eq.
+          length.
+            str
+          0
+        ""
+        if.
+          eq.
+            slice.
+                str
+                0
+                1
+              " "
+          rec-trim
+            slice.
+              str
+              1
+              plus.
+                length.
+                  str
+                -1
+          str
 
   # Trim it from both sides
   # @todo #107:30min Current implementation of trimmed method catches stackoverflow

--- a/src/main/eo/org/eolang/txt/text.eo
+++ b/src/main/eo/org/eolang/txt/text.eo
@@ -38,23 +38,32 @@
 
   # Returns string trimmed from left side
   [] > left-trim
-    if. > @
-      eq.
-        length.
-          s
-        0
-      ""
-      left-trim-rec.
-        s
+    left-rec-trim > @
+      s
 
     [str] > left-rec-trim
       if. > @
         eq.
-          str.slice 0 1
-          " "
-        left-rec-trim.
-          str.slice 1 (str.length)
-      str
+          length.
+            str
+          0
+        ""
+        if.
+          eq.
+            slice.
+              str
+              0
+              1
+            " "
+          left-rec-trim
+            slice.
+              str
+              1
+              plus.
+                length.
+                  str
+                -1
+          str
 
   # Trim it from both sides
   # @todo #107:30min Current implementation of trimmed method catches stackoverflow

--- a/src/test/eo/org/eolang/txt/text-tests.eo
+++ b/src/test/eo/org/eolang/txt/text-tests.eo
@@ -29,6 +29,48 @@
 +package org.eolang.txt
 +version 0.0.0
 
+[] > text-left-trim-1
+  assert-that > @
+    left-trim.
+      text
+        "a b"
+    $.equal-to "a b"
+
+[] > text-left-trim-2
+  assert-that > @
+    left-trim.
+      text
+        "a b "
+    $.equal-to "a b "
+
+[] > text-left-trim-3
+  assert-that > @
+    left-trim.
+      text
+        " a b "
+    $.equal-to "a b "
+
+[] > text-left-trim-4
+  assert-that > @
+    left-trim.
+      text
+        " a b"
+    $.equal-to "a b"
+
+[] > text-left-trim-space
+  assert-that > @
+    left-trim.
+      text
+        " "
+    $.equal-to ""
+
+[] > text-left-trim-double-space
+  assert-that > @
+    left-trim.
+      text
+        "  "
+    $.equal-to ""
+
 [] > text-trimmed-1
   assert-that > @
     trimmed.


### PR DESCRIPTION
Closes: https://github.com/objectionary/eo-strings/issues/142

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `left-trim` method to the `text.eo` file and includes test cases for it. 

### Detailed summary
- Adds `left-trim` method to `text.eo`
- Includes test cases for `left-trim`
- Fixes a typo in README.md

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->